### PR TITLE
ENH: Support building the module externally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,13 @@
+if(NOT VTK_SOURCE_DIR)
+  cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+  project(PoissonReconstruction)
+  find_package(VTK REQUIRED)
+endif()
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${VTK_CMAKE_DIR}")
+if(NOT VTK_SOURCE_DIR)
+  include(vtkExternalModuleMacros)
+endif()
+
 message(STATUS "SplineDrivenImageSlicer: Building as a Remote VTK module")
 
 set(Module_SRCS


### PR DESCRIPTION
This enables building the module against an existing VTK build tree so that
it could be build, tested, packaged independently.

Note that with this commit, using VTK >= 8.1 (newer than kitware/VTK@061eff0
from October 18th 2017) is required.