### PR TITLE
Mark destructor with override keyword

### DIFF
--- a/vtkFrenetSerretFrame.h
+++ b/vtkFrenetSerretFrame.h
@@ -73,7 +73,7 @@ public:
 
 protected:
   vtkFrenetSerretFrame();
-  ~vtkFrenetSerretFrame();
+  ~vtkFrenetSerretFrame() override;
 
   virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
   virtual int FillInputPortInformation(int port, vtkInformation *info) override;


### PR DESCRIPTION
Silences warning turned up with Clang option
-Winconsistent-missing-destructor-override.

Fixes warning turned up with new warning options on VTK dashboard machine `trey`: https://open.cdash.org/viewBuildError.php?type=1&buildid=6246282